### PR TITLE
Update Workflow to Fetch Files and Deploy to GitHub Pages ('static.yml')

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,68 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+  # Scheduled run every 12 hours
+  schedule:
+    - cron: '0 */12 * * *'  # This will run the action every 12 hours
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout public `.io` repo
+        uses: actions/checkout@v2
+        with:
+          path: IEEE-Coogs.github.io
+          ref: main
+
+      - name: Checkout private repo
+        uses: actions/checkout@v2
+        with:
+          repository: IEEE-Coogs/DevOps-and-frontend  # Correct path to the private repo within the organization
+          token: ${{ secrets.PAT_TOKEN }}  # Use your PAT token stored in secrets
+          path: DevOps-and-frontend
+          ref: main
+
+      - name: Copy HTML, CSS, and JS files
+        run: |
+          mkdir -p IEEE-Coogs.github.io/public/html-files
+          cp DevOps-and-frontend/src/html/*.html IEEE-Coogs.github.io/public/html-files/
+          cp DevOps-and-frontend/src/css/*.css IEEE-Coogs.github.io/public/html-files/
+          cp DevOps-and-frontend/src/js/*.js IEEE-Coogs.github.io/public/html-files/
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload the public directory
+          path: 'IEEE-Coogs.github.io/public'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

This pull request updates the GitHub Actions workflow to automate the process of fetching HTML, CSS, and JS files from a private repository and deploying them to the GitHub Pages site. The workflow is designed to run on pushes to the main branch, manual triggers, and a scheduled run every 12 hours.

## Changes Made

- Modified the `.github/workflows/static.yml` file to include steps for:
  - Checking out the public `.io` repository.
  - Checking out the private `DevOps-and-frontend` repository.
  - Copying HTML, CSS, and JS files from the private repo to the public repo.
  - Configuring GitHub Pages deployment settings.
  - Uploading artifacts for deployment.
  - Deploying the content to GitHub Pages.

## Workflow Triggers

- The workflow runs on:
  - Pushes to the `main` branch.
  - Manual triggers from the Actions tab.
  - A scheduled run every 12 hours.

## Testing

- Verified that the workflow runs successfully and completes without errors.
- Confirmed that the changes are reflected on the GitHub Pages site.

## Notes

- Ensure that the `PAT_TOKEN` secret is correctly configured in the repository settings to allow access to the private repository.
- Monitor the first few runs to ensure that the workflow operates as expected and the changes are correctly deployed.

## Additional Information

If you have any questions or need further clarification, please feel free to ask in the comments.

